### PR TITLE
Fix starship prompt and fzf not found on first login

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -1,6 +1,10 @@
 # --- Dotfiles location (resolved from symlink) ---
 DOTFILES_DIR="${${(%):-%x}:A:h}"
 
+# --- PATH (early, so tools like starship/fzf are available below) ---
+export PATH=$HOME/.local/bin:$PATH
+export PATH="$HOME/go/bin:$PATH"
+
 # --- Prompt ---
 if command -v starship &>/dev/null; then
   eval "$(starship init zsh)"
@@ -88,10 +92,6 @@ if [[ "$(uname 2> /dev/null)" == "Linux" ]]; then
 fi
 
 alias make=safemake.sh
-
-# --- PATH ---
-export PATH=$HOME/.local/bin:$PATH
-export PATH="$HOME/go/bin:$PATH"
 
 # --- CUDA (only if present) ---
 if [[ -d /usr/local/cuda ]]; then


### PR DESCRIPTION
## Summary
- Move PATH setup (`~/.local/bin`, `~/go/bin`) to the top of `zshrc`, before starship and fzf initialization
- Fixes "command not found: fzf" error and wrong prompt on first login (starship/fzf live in `~/.local/bin` which wasn't on PATH when they were referenced)
- Nested `zsh` shells worked fine because they inherited the parent's already-updated PATH

## Test plan
- [x] SSH into a fresh session and verify starship prompt loads immediately (no fallback to af-magic)
- [x] Verify no `command not found: fzf` error on login
- [x] Verify `Ctrl-R` (fzf history search) works in the first shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)