### PR TITLE
Enable claudectx zsh tab completion

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -113,6 +113,9 @@ kubectl() {
 }
 alias k=kubectl
 
+# claudectx tab completion (profile names are fetched live at completion time)
+(( $+commands[claudectx] )) && eval "$(claudectx completion zsh)"
+
 if [[ "$(uname 2> /dev/null)" == "Linux" ]]; then
     alias pbcopy='xclip -sel clip'
     alias open='xdg-open'


### PR DESCRIPTION
Registers claudectx tab completion in zsh via `eval "$(claudectx completion zsh)"`, guarded on the command existing. Completion candidates (subcommands, flags, profile names) are fetched live by the completion script, so nothing needs regenerating when profiles change.

Requires a claudectx build that has the `completion` subcommand (tlrmchlsmth/claudectx PR adding it is up separately); on hosts with an older binary the guard still passes but startup prints an unknown-command warning — update claudectx there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)