### PR TITLE
Add crew-agent container image + multi-arch ghcr CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.github
+container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,39 @@ jobs:
             exit 1
           fi
 
+  agent-image:
+    name: Agent image (crew-agent)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        if: github.ref == 'refs/heads/main'
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: container/agent/Containerfile
+          # PRs prove the build on one arch; main builds both and pushes.
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: |
+            ghcr.io/tlrmchlsmth/crew-agent:latest
+            ghcr.io/tlrmchlsmth/crew-agent:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   CI:
     if: always()
-    needs: [install, install-container]
+    needs: [install, install-container, agent-image]
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/container/agent/Containerfile
+++ b/container/agent/Containerfile
@@ -1,0 +1,51 @@
+# crew-agent: the container image autonomous agents (claude/codex) run in,
+# launched by crew (github.com/tlrmchlsmth/crew). Generic dev environment —
+# tools + dotfiles only; crew injects its own protocol scripts at runtime,
+# and claudectx injects agent config + credentials.
+FROM registry.fedoraproject.org/fedora:latest
+
+ARG TARGETARCH
+
+# System packages as root; gh and neovim come from the Fedora repos, so
+# install.sh's dnf steps below are no-ops.
+RUN dnf install -y --setopt=install_weak_deps=False \
+        git curl zsh tmux ripgrep bat jq less procps-ng openssh-clients \
+        unzip tar findutils which hostname ca-certificates \
+        python3-pip neovim gh fontconfig \
+    && dnf clean all
+
+# kubectl (arch-aware, stable channel)
+RUN KVER="$(curl -fsSL https://dl.k8s.io/release/stable.txt)" \
+    && curl -fsSL -o /usr/local/bin/kubectl \
+        "https://dl.k8s.io/release/${KVER}/bin/linux/${TARGETARCH}/kubectl" \
+    && chmod 0755 /usr/local/bin/kubectl
+
+# Non-root agent user with passwordless sudo: install.sh drives dnf via
+# `sudo -n`, and agents may legitimately install task dependencies — the
+# container, not in-container privilege, is the isolation boundary.
+RUN useradd -m -s /usr/bin/zsh -G wheel tms \
+    && echo '%wheel ALL=(ALL) NOPASSWD: ALL' > /etc/sudoers.d/wheel \
+    && mkdir -p /work && chown tms:tms /work
+
+USER tms
+WORKDIR /home/tms
+ENV PATH=/home/tms/.local/bin:/home/tms/.fzf/bin:$PATH
+
+# Agent CLIs: claude (official installer), codex (musl release binary), uv.
+RUN mkdir -p /home/tms/.local/bin \
+    && curl -fsSL https://claude.ai/install.sh | bash \
+    && RUST_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo aarch64 || echo x86_64) \
+    && curl -fsSL -o /tmp/codex.tar.gz \
+        "https://github.com/openai/codex/releases/latest/download/codex-${RUST_ARCH}-unknown-linux-musl.tar.gz" \
+    && tar -xzf /tmp/codex.tar.gz -C /tmp \
+    && mv /tmp/codex-${RUST_ARCH}-unknown-linux-musl /home/tms/.local/bin/codex \
+    && rm -f /tmp/codex.tar.gz \
+    && curl -fsSL https://astral.sh/uv/install.sh | sh
+
+# Dotfiles last — they change most often.
+COPY --chown=tms:tms . /home/tms/.dotfiles
+RUN bash /home/tms/.dotfiles/install.sh
+
+ENV SHELL=/usr/bin/zsh TERM=xterm-256color
+WORKDIR /work
+CMD ["/usr/bin/zsh", "-l"]


### PR DESCRIPTION
## What

The container image autonomous agents run in under [crew](https://github.com/tlrmchlsmth/crew), the agent orchestrator being built in conductor.

- `container/agent/Containerfile`: Fedora base, non-root `tms` user (passwordless sudo so install.sh's dnf steps and agent dependency installs work — the container is the isolation boundary, not in-container privilege). Bundles claude + codex + gh + kubectl + git/zsh/tmux/ripgrep/jq/nvim and the dotfiles via `install.sh`.
- Generic dev environment only: crew injects its run-protocol scripts and claudectx injects agent config + credentials at launch, so the image stays decoupled from both.
- New `agent-image` CI job (buildx): **PRs** build `linux/amd64` to prove the Containerfile; **main** builds `linux/amd64,linux/arm64` and pushes `ghcr.io/tlrmchlsmth/crew-agent:{latest,sha}`.

## Verified

Built locally with podman (arm64) and ran the image:

```
user=tms home=/home/tms
claude 2.1.176 · codex 0.139.0 · gh 2.92.0 · kubectl v1.36.2 · tmux 3.6b · git 2.54.0 · rg 14.1.1
```

## Follow-up (not blocking)

After first push to main, make the `crew-agent` ghcr package **public** so `podman pull` needs no auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)