### PR TITLE
Add per-shell Kubernetes context isolation and import helper

### DIFF
--- a/config/starship.toml
+++ b/config/starship.toml
@@ -5,7 +5,7 @@ add_newline = true
 format = """
 $hostname$directory$git_branch$git_status$python\
 $fill\
-$time\
+$kubernetes $time\
 $line_break\
 $character"""
 
@@ -74,6 +74,11 @@ disabled = true
 
 [java]
 disabled = true
+
+[kubernetes]
+disabled = false
+format = '[$context(|$namespace)]($style)'
+style = '105'
 
 [cmd_duration]
 disabled = true

--- a/zshrc
+++ b/zshrc
@@ -172,6 +172,45 @@ kns() {
   [[ -n "$ns" ]] && kubectl config set-context --current --namespace="$ns"
 }
 
+kubeimport() {
+  local force=0
+  if [[ "$1" == "-f" ]]; then
+    force=1
+    shift
+  fi
+  if (( $# > 1 )); then
+    echo "usage: kubeimport [-f] [name]" >&2
+    return 2
+  fi
+
+  local name="${1:-$(kubectl config current-context 2>/dev/null)}"
+  if [[ -z "$name" || "$name" == *[^A-Za-z0-9._-]* ]]; then
+    echo "kubeimport: name must contain only letters, numbers, '.', '_', or '-'" >&2
+    return 2
+  fi
+
+  local dir="$HOME/.kube/configs"
+  local dest="$dir/$name.yaml"
+  mkdir -p "$dir" || return
+  chmod 700 "$HOME/.kube" "$dir" || return
+  if [[ -e "$dest" && $force -eq 0 ]]; then
+    echo "kubeimport: $dest already exists (use -f to replace it)" >&2
+    return 1
+  fi
+
+  local tmp=$(mktemp "$dir/.$name.XXXXXX") || return
+  chmod 600 "$tmp"
+  if ! kubectl config view --minify --flatten --raw > "$tmp" ||
+     ! KUBECONFIG="$tmp" command kubectl config current-context &>/dev/null; then
+    rm -f "$tmp"
+    echo "kubeimport: could not export the current context" >&2
+    return 1
+  fi
+
+  mv -f "$tmp" "$dest" || return
+  echo "Imported $(kubectl config current-context) into $dest"
+}
+
 # --- Extra paths ---
 fpath+=~/.config/zsh/.zsh_functions
 

--- a/zshrc
+++ b/zshrc
@@ -150,6 +150,28 @@ if [[ -n "$TMUX" ]]; then
     fi
 fi
 
+# --- Kubernetes: per-shell context isolation ---
+if [[ -d ~/.kube/configs ]]; then
+  setopt localoptions null_glob
+  local cfgs=(~/.kube/configs/*.yaml ~/.kube/configs/*.yml)
+  if (( ${#cfgs} )); then
+    local _kube_shell=$(mktemp ~/.kube/shell.XXXXXX)
+    local _ctx="$(cat ~/.kube/last-context 2>/dev/null || echo pirate)"
+    printf 'apiVersion: v1\ncurrent-context: %s\nkind: Config\n' "$_ctx" > "$_kube_shell"
+    export KUBECONFIG="$_kube_shell:${(j.:.)cfgs}"
+    trap "rm -f '$_kube_shell'" EXIT
+  fi
+fi
+
+kctx() {
+  local ctx="${1:-$(kubectl config get-contexts -o name | fzf --height=~50% --prompt='ctx> ')}"
+  [[ -n "$ctx" ]] && kubectl config use-context "$ctx" && echo "$ctx" > ~/.kube/last-context
+}
+kns() {
+  local ns="${1:-$(kubectl get namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | fzf --height=~50% --prompt='ns> ')}"
+  [[ -n "$ns" ]] && kubectl config set-context --current --namespace="$ns"
+}
+
 # --- Extra paths ---
 fpath+=~/.config/zsh/.zsh_functions
 


### PR DESCRIPTION
## Summary
- Each terminal gets its own `current-context` via a per-shell temp KUBECONFIG file — switching context in one terminal no longer affects others
- `kctx` / `kns` provide fzf context and namespace pickers
- `kubeimport [-f] [name]` securely exports the active context into `~/.kube/configs`
- Starship shows the active Kubernetes context and namespace

## Test plan
- [x] Run an ad-hoc isolated test for `kubeimport` export, context/namespace preservation, mode `600`, overwrite protection, and `-f` replacement
- [x] Validate `zshrc` with `zsh -n`
- [ ] Open two terminals and select different contexts with `kctx` to verify isolation
- [ ] Confirm `kns` only changes the current terminal
- [ ] Confirm the Starship prompt shows `context|namespace`
- [ ] Close a terminal and verify its temporary kubeconfig is removed
