### PR TITLE
Prompt for kubeimport config name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run install.sh
         run: bash install.sh
+      - name: Run zsh tests
+        run: zsh tests/kubeimport.zsh
       - name: Verify key binaries
         shell: zsh {0}
         run: |
@@ -63,6 +65,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run install.sh
         run: bash install.sh
+      - name: Run zsh tests
+        run: zsh tests/kubeimport.zsh
       - name: Verify key binaries
         shell: zsh {0}
         run: |

--- a/tests/kubeimport.zsh
+++ b/tests/kubeimport.zsh
@@ -1,0 +1,61 @@
+#!/bin/zsh
+set -e
+
+repo_root=${0:A:h:h}
+test_home=$(mktemp -d)
+trap 'rm -rf "$test_home"' EXIT
+mkdir -p "$test_home/.local/bin"
+
+cat > "$test_home/.local/bin/kubectl" <<'EOF'
+#!/bin/sh
+case "$*" in
+  "config current-context")
+    printf '%s\n' source-context
+    ;;
+  "config view --minify --flatten --raw")
+    cat <<'YAML'
+apiVersion: v1
+kind: Config
+current-context: source-context
+YAML
+    ;;
+  "completion zsh")
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$test_home/.local/bin/kubectl"
+
+export HOME=$test_home
+set +e
+source "$repo_root/zshrc" >/dev/null 2>&1
+set -e
+if ! whence kubeimport >/dev/null; then
+  print -u2 "zshrc did not define kubeimport"
+  exit 1
+fi
+printf 'friendly-name\n' | kubeimport >/dev/null
+
+expected="$test_home/.kube/configs/friendly-name.yaml"
+if [[ ! -f "$expected" ]]; then
+  print -u2 "expected interactive name to create $expected"
+  exit 1
+fi
+
+kubeimport positional-name >/dev/null
+expected="$test_home/.kube/configs/positional-name.yaml"
+if [[ ! -f "$expected" ]]; then
+  print -u2 "expected positional name to create $expected"
+  exit 1
+fi
+
+printf '\n' | kubeimport >/dev/null
+expected="$test_home/.kube/configs/source-context.yaml"
+if [[ ! -f "$expected" ]]; then
+  print -u2 "expected empty input to use current context at $expected"
+  exit 1
+fi
+
+print 'kubeimport tests passed'

--- a/zshrc
+++ b/zshrc
@@ -188,7 +188,14 @@ kubeimport() {
     return 2
   fi
 
-  local name="${1:-$(kubectl config current-context 2>/dev/null)}"
+  local name
+  if (( $# == 1 )); then
+    name="$1"
+  else
+    local current="$(kubectl config current-context 2>/dev/null)"
+    read "name?kubeconfig name [$current]: " || return
+    name="${name:-$current}"
+  fi
   if [[ -z "$name" || "$name" == *[^A-Za-z0-9._-]* ]]; then
     echo "kubeimport: name must contain only letters, numbers, '.', '_', or '-'" >&2
     return 2


### PR DESCRIPTION
## Summary
- prompt for a kubeconfig filename when `kubeimport` is called without a name
- default to the current context when the prompt is left blank
- preserve positional naming for scripts
- exercise kubeimport behavior in the existing cross-platform CI jobs

## Test plan
- [x] `zsh -n zshrc tests/kubeimport.zsh`
- [x] `zsh tests/kubeimport.zsh`
- [x] `git diff --check`