### PR TITLE
Fix kubeimport context refresh

### DIFF
--- a/tests/kubeimport.zsh
+++ b/tests/kubeimport.zsh
@@ -10,14 +10,41 @@ cat > "$test_home/.local/bin/kubectl" <<'EOF'
 #!/bin/sh
 case "$*" in
   "config current-context")
-    printf '%s\n' source-context
+    if [ -n "$KUBECONFIG" ] && [ -f "$KUBECONFIG" ]; then
+      sed -n 's/^current-context: *//p' "$KUBECONFIG"
+    else
+      printf '%s\n' source-context
+    fi
+    ;;
+  "config view --minify --raw -o jsonpath={.clusters[0].cluster.server}")
+    if [ -n "$KUBECONFIG" ] && [ -f "$KUBECONFIG" ]; then
+      sed -n 's/^    server: *//p' "$KUBECONFIG"
+    else
+      printf '%s\n' https://source.example.test
+    fi
     ;;
   "config view --minify --flatten --raw")
     cat <<'YAML'
 apiVersion: v1
+clusters:
+- cluster:
+    server: https://source.example.test
+  name: source-cluster
 kind: Config
 current-context: source-context
+users:
+- name: source-user
+  user:
 YAML
+    printf '    token: %s\n' "${KUBEIMPORT_TEST_TOKEN:-initial-token}"
+    ;;
+  "config rename-context "*)
+    old_context=$3
+    new_context=$4
+    awk -v old="$old_context" -v new="$new_context" '
+      $0 == "current-context: " old { print "current-context: " new; next }
+      { print }
+    ' "$KUBECONFIG" > "$KUBECONFIG.renamed" && mv "$KUBECONFIG.renamed" "$KUBECONFIG"
     ;;
   "completion zsh")
     ;;
@@ -41,6 +68,30 @@ printf 'friendly-name\n' | kubeimport >/dev/null
 expected="$test_home/.kube/configs/friendly-name.yaml"
 if [[ ! -f "$expected" ]]; then
   print -u2 "expected interactive name to create $expected"
+  exit 1
+fi
+if [[ "$(sed -n 's/^current-context: *//p' "$expected")" != friendly-name ]]; then
+  print -u2 "expected imported context to be named friendly-name"
+  exit 1
+fi
+
+KUBEIMPORT_TEST_TOKEN=refreshed-token kubeimport friendly-name >/dev/null
+if ! grep -q 'token: refreshed-token' "$expected"; then
+  print -u2 "expected importing the same context to refresh $expected"
+  exit 1
+fi
+
+cat > "$test_home/.kube/configs/collision.yaml" <<'EOF'
+apiVersion: v1
+kind: Config
+current-context: source-context
+clusters:
+- cluster:
+    server: https://other.example.test
+  name: other-cluster
+EOF
+if kubeimport collision >/dev/null 2>&1; then
+  print -u2 "expected a different existing cluster to require -f"
   exit 1
 fi
 

--- a/tests/kubeimport.zsh
+++ b/tests/kubeimport.zsh
@@ -46,6 +46,9 @@ YAML
       { print }
     ' "$KUBECONFIG" > "$KUBECONFIG.renamed" && mv "$KUBECONFIG.renamed" "$KUBECONFIG"
     ;;
+  "config use-context "*)
+    printf '%s\n' "$3" > "$HOME/.kubectl-used-context"
+    ;;
   "completion zsh")
     ;;
   *)
@@ -72,6 +75,14 @@ if [[ ! -f "$expected" ]]; then
 fi
 if [[ "$(sed -n 's/^current-context: *//p' "$expected")" != friendly-name ]]; then
   print -u2 "expected imported context to be named friendly-name"
+  exit 1
+fi
+if [[ "$(<"$test_home/.kube/last-context")" != friendly-name ]]; then
+  print -u2 "expected imported context to be saved for new shells"
+  exit 1
+fi
+if [[ "$(<"$test_home/.kubectl-used-context")" != friendly-name ]]; then
+  print -u2 "expected imported context to be activated in the current shell"
   exit 1
 fi
 

--- a/zshrc
+++ b/zshrc
@@ -201,13 +201,25 @@ kubeimport() {
     return 2
   fi
 
+  local source_context="$(kubectl config current-context 2>/dev/null)"
+  if [[ -z "$source_context" ]]; then
+    echo "kubeimport: no current context to import" >&2
+    return 1
+  fi
+  local source_server="$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null)"
+
   local dir="$HOME/.kube/configs"
   local dest="$dir/$name.yaml"
   mkdir -p "$dir" || return
   chmod 700 "$HOME/.kube" "$dir" || return
   if [[ -e "$dest" && $force -eq 0 ]]; then
-    echo "kubeimport: $dest already exists (use -f to replace it)" >&2
-    return 1
+    local dest_context="$(KUBECONFIG="$dest" command kubectl config current-context 2>/dev/null)"
+    local dest_server="$(KUBECONFIG="$dest" command kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null)"
+    if [[ "$dest_context" != "$source_context" && "$dest_context" != "$name" ]] ||
+       [[ -z "$source_server" || "$dest_server" != "$source_server" ]]; then
+      echo "kubeimport: $dest contains context '$dest_context' (use -f to replace it)" >&2
+      return 1
+    fi
   fi
 
   local tmp=$(mktemp "$dir/.$name.XXXXXX") || return
@@ -218,9 +230,15 @@ kubeimport() {
     echo "kubeimport: could not export the current context" >&2
     return 1
   fi
+  if [[ "$source_context" != "$name" ]] &&
+     ! KUBECONFIG="$tmp" command kubectl config rename-context "$source_context" "$name" &>/dev/null; then
+    rm -f "$tmp"
+    echo "kubeimport: could not rename context '$source_context' to '$name'" >&2
+    return 1
+  fi
 
   mv -f "$tmp" "$dest" || return
-  echo "Imported $(kubectl config current-context) into $dest"
+  echo "Imported $source_context as $name into $dest"
 }
 
 # --- Extra paths ---

--- a/zshrc
+++ b/zshrc
@@ -238,6 +238,11 @@ kubeimport() {
   fi
 
   mv -f "$tmp" "$dest" || return
+  echo "$name" > "$HOME/.kube/last-context" || return
+  if ! kubectl config use-context "$name" &>/dev/null; then
+    echo "kubeimport: imported $name, but could not activate it in this shell" >&2
+    return 1
+  fi
   echo "Imported $source_context as $name into $dest"
 }
 


### PR DESCRIPTION
## Summary
- rename imported contexts to the requested kubeconfig name
- allow re-login token refreshes to replace the matching stored context
- preserve force protection for conflicting clusters

## Testing
- `zsh tests/kubeimport.zsh`
- `zsh -n zshrc tests/kubeimport.zsh`
- `git diff --check`