### PR TITLE
nvim: ignore worktree directories in file finder

### DIFF
--- a/config/nvim/lua/plugins/init.lua
+++ b/config/nvim/lua/plugins/init.lua
@@ -174,7 +174,7 @@ return {
     config = function()
       local exclude_patterns = {
         ".git", ".venv", ".mypy_cache", "__pycache__",
-        ".github", ".deps", ".ruff_cache", "*.so", "*.o"
+        ".github", ".deps", ".ruff_cache", ".worktree", "*.so", "*.o"
       }
 
       local fd_command_parts = {"fd --type f --hidden --follow"}


### PR DESCRIPTION
## Summary

- exclude `.worktree` directories from fzf-lua file discovery
- apply the exclusion to both the fd and find implementations

## Validation

- `git diff --check`
- loaded the Neovim Lua config headlessly