### PR TITLE
nvim: replace vim-oscyank with native OSC 52 clipboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,14 +47,19 @@ The script detects the OS/distro and uses the appropriate package manager (apt/d
 Neovim uses a Lua-based configuration with lazy.nvim plugin manager:
 
 - **Entry point**: `config/nvim/init.lua` (sets leader to `,`, bootstraps lazy.nvim)
-- **Core modules**: `lua/core/{options,autocmds,keymaps}.lua`
+- **Core modules**: `lua/core/{options,autocmds,keymaps,osc52}.lua`
 - **Plugins**: `lua/plugins/init.lua` (single file with all plugin specs)
 
 Key plugins:
 - **LSP**: mason.nvim, mason-lspconfig.nvim, nvim-lspconfig (servers: lua_ls, ty, rust_analyzer)
 - **UI**: gruvbox theme, lualine, trouble.nvim, nvim-tree
 - **Fuzzy finding**: fzf-lua (uses `fd` or `find`, excludes `.git`, `.venv`, `__pycache__`, etc.)
-- **Utilities**: vim-fugitive, vim-surround, vim-oscyank
+- **Utilities**: vim-fugitive, vim-surround
+
+**Clipboard over SSH**: `lua/core/osc52.lua` writes OSC 52 escape sequences using
+Neovim's built-in `vim.ui.clipboard.osc52` writer. Mapped to `<leader>c` (operator),
+`<leader>cc` (line), and `<leader>c` in visual mode. This replaced `vim-oscyank`,
+whose pure-Vimscript base64 encoder took ~2.7s to copy 100KB.
 
 ### Zsh Configuration
 

--- a/config/nvim/lua/core/keymaps.lua
+++ b/config/nvim/lua/core/keymaps.lua
@@ -19,10 +19,12 @@ map('n', 'gR', '<cmd>TroubleToggle lsp_references<cr>', { desc = 'LSP References
 -- LSP Mappings (will be attached in lspconfig setup)
 -- Note: 'gD', 'gd', 'K', 'gr' are often handled by lspconfig's on_attach function
 
--- OSCYank Mappings (Clipboard over SSH)
-map('n', '<leader>c', '<Plug>OSCYankOperator', { desc = 'OSCYank Operator' })
-map('n', '<leader>cc', '<leader>c_', { desc = 'OSCYank Line' })
-map('v', '<leader>c', '<Plug>OSCYankVisual', { desc = 'OSCYank Visual' })
+-- OSC 52 Mappings (Clipboard over SSH)
+local osc52 = require('core.osc52')
+map('n', '<leader>c', osc52.operator, { expr = true, desc = 'OSC52 Yank Operator' })
+map('n', '<leader>cc', function() return osc52.operator() .. '_' end, { expr = true, desc = 'OSC52 Yank Line' })
+-- `:<C-u>` (rather than a Lua callback) so we leave visual mode and '</'> are set
+map('v', '<leader>c', [[:<C-u>lua require('core.osc52').visual()<CR>]], { desc = 'OSC52 Yank Visual' })
 
 -- Single Character Insert
 map('n', 's', function() vim.cmd('normal! i' .. vim.fn.nr2char(vim.fn.getchar()) .. '\x1b') end, opts)
@@ -83,6 +85,8 @@ map('v', '//', 'y/\\V<C-R>"<CR>', { noremap = true, silent = false, desc = 'Sear
 -- Disable K (keyword lookup) if not using LSP default or want it free
 -- map('n', 'K', '<Nop>', opts)
 
--- C++/Header switching (moved to utils and called from here)
-map('n', '<Leader>c', function() require('utils.file_switch').switch_cpp_header('cpp') end, { desc = 'Switch to C++ Source' })
+-- C++/Header switching
+-- NOTE: utils/file_switch.lua does not exist, so this errors when invoked.
+-- The <Leader>c variant was also shadowing the OSC52 yank operator above and
+-- has been dropped; restore it under a different key if file_switch is written.
 map('n', '<Leader>h', function() require('utils.file_switch').switch_cpp_header('hpp') end, { desc = 'Switch to C++ Header' })

--- a/config/nvim/lua/core/osc52.lua
+++ b/config/nvim/lua/core/osc52.lua
@@ -1,0 +1,58 @@
+-- ~/.config/nvim/lua/core/osc52.lua
+--
+-- Copy to the local system clipboard over SSH via the OSC 52 escape sequence.
+--
+-- Replaces ojroques/vim-oscyank, whose base64 encoder is a pure-Vimscript loop
+-- (~26us per byte: 2.7s to copy 100KB). Neovim's built-in OSC 52 writer uses
+-- vim.base64.encode in C, which is ~20000x faster.
+
+local M = {}
+
+local copy = require('vim.ui.clipboard.osc52').copy('+')
+
+-- Yank the region described by `cmd` into register z without disturbing the
+-- unnamed register, the visual marks, or 'selection'.
+local function get_text(cmd)
+  local register = vim.fn.getreginfo('z')
+  local selection = vim.o.selection
+  local marks = { vim.fn.getpos("'<"), vim.fn.getpos("'>") }
+
+  vim.o.selection = 'inclusive'
+  vim.cmd('keepjumps silent normal! ' .. cmd)
+  local text = vim.fn.getreg('z')
+
+  vim.fn.setreg('z', register)
+  vim.o.selection = selection
+  vim.fn.setpos("'<", marks[1])
+  vim.fn.setpos("'>", marks[2])
+
+  return text
+end
+
+function M.yank(text)
+  copy(vim.split(text, '\n', { plain = true }))
+  vim.notify(string.format('[osc52] %d characters copied', #text))
+end
+
+-- 'operatorfunc' callback: motion_type is one of 'char', 'line', 'block'.
+function M.operator_callback(motion_type)
+  local cmd = ({
+    char = '`[v`]"zy',
+    line = "'[V']\"zy",
+    block = '`[' .. vim.keycode('<C-v>') .. '`]"zy',
+  })[motion_type]
+  M.yank(get_text(cmd))
+end
+
+function M.operator()
+  vim.o.operatorfunc = "v:lua.require'core.osc52'.operator_callback"
+  return 'g@'
+end
+
+-- Call this only after leaving visual mode (the mapping uses `:<C-u>`), so that
+-- '< and '> are up to date and `gv` reselects the region the user just had.
+function M.visual()
+  M.yank(get_text('gv"zy'))
+end
+
+return M

--- a/config/nvim/lua/plugins/init.lua
+++ b/config/nvim/lua/plugins/init.lua
@@ -269,7 +269,7 @@ return {
   },
 
   -- ========== Other Plugins ==========
-  { 'ojroques/vim-oscyank', branch = 'main', event = 'VeryLazy' },
+  -- (OSC 52 clipboard is handled natively in core/osc52.lua, no plugin needed)
 
   -- ========== Task Runner ==========
   {


### PR DESCRIPTION
Copying out of nvim over SSH was very slow. Two separate problems.

## 1. `vim-oscyank` base64-encodes in pure Vimscript

[`plugin/oscyank.vim`](https://github.com/ojroques/vim-oscyank/blob/main/plugin/oscyank.vim) builds the base64 string one character at a time in an interpreted loop — about 26 µs *per byte*. Neovim 0.10+ ships an OSC 52 writer backed by `vim.base64.encode` in C, so the plugin is redundant on nvim 0.11.

| bytes | vim-oscyank | `vim.base64` |
|------:|------------:|-------------:|
| 1,000 | 22.5 ms | 0.003 ms |
| 5,000 | 112.1 ms | 0.017 ms |
| 20,000 | 464.5 ms | 0.025 ms |
| 50,000 | 1207.0 ms | 0.066 ms |
| 100,000 | 2664.5 ms | 0.130 ms |

This adds `lua/core/osc52.lua` wrapping `vim.ui.clipboard.osc52` and drops the plugin.

**Yanking a 100KB file goes from ~2700 ms to 1.1 ms.**

Mappings and their semantics are unchanged — `<leader>c` (operator), `<leader>cc` (line), `<leader>c` (visual). The unnamed register, visual marks and `'selection'` are all saved and restored, and `<leader>cc` still respects counts (it composes the operator with `_`, same as the old `<leader>c_`).

## 2. `<leader>c` in normal mode was dead

`keymaps.lua` re-mapped `<Leader>c` to a C++/header switcher 65 lines below the OSCYank mapping, silently shadowing it. That handler calls `utils.file_switch`, a module that does not exist in this repo (`lua/utils/` contains only `theme.lua`), so `<leader>c` + motion raised module-not-found instead of copying anything. Only `<leader>cc` and the visual-mode mapping were reaching oscyank at all.

The colliding `<Leader>c` line is removed. `<Leader>h` is left in place with a comment — it is broken for the same reason, but writing `file_switch.lua` is separate work.

## Verification

Drove the real keymaps with actual keystrokes via `nvim_feedkeys` against a 100KB buffer:

```
visual whole file 100KB      PASS  (1.1 ms)
operator ,c2j (linewise)     PASS
operator ,cw (charwise)      PASS
line ,cc                     PASS
line 3,cc (count)            PASS
visual charwise v4l          PASS
visual blockwise             PASS
unnamed register untouched   PASS
register z restored          PASS
'selection' restored         PASS
back in normal mode          PASS
```

## Note

Neovim terminates the sequence with ST (`ESC \`) where vim-oscyank used BEL (`\x07`). Both are standard and tmux normalizes via its `Ms` capability, so this should be transparent — but it is the first thing to check if copy stops reaching the local clipboard.

Run `:Lazy clean` after merging to drop the unused vim-oscyank checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)