### PR TITLE
nvim: drop vestigial C++/header switching mapping

### DIFF
--- a/config/nvim/lua/core/keymaps.lua
+++ b/config/nvim/lua/core/keymaps.lua
@@ -84,9 +84,3 @@ map('v', '//', 'y/\\V<C-R>"<CR>', { noremap = true, silent = false, desc = 'Sear
 
 -- Disable K (keyword lookup) if not using LSP default or want it free
 -- map('n', 'K', '<Nop>', opts)
-
--- C++/Header switching
--- NOTE: utils/file_switch.lua does not exist, so this errors when invoked.
--- The <Leader>c variant was also shadowing the OSC52 yank operator above and
--- has been dropped; restore it under a different key if file_switch is written.
-map('n', '<Leader>h', function() require('utils.file_switch').switch_cpp_header('hpp') end, { desc = 'Switch to C++ Header' })


### PR DESCRIPTION
Follow-up to #24. **Based on that branch, not `main`** — it touches the same lines, so merge #24 first and the base will retarget to `main` automatically.

`<Leader>h` called `utils.file_switch`, a module that has never existed in this repo — `lua/utils/` contains only `theme.lua`. The mapping raised module-not-found on every invocation. Its `<Leader>c` counterpart was removed in #24 for shadowing the OSC52 yank operator, which left this one behind with an explanatory note.

Nothing else in the tree references `file_switch` or `switch_cpp_header`. Removing the mapping and the note rather than carrying a keybind that cannot work; `<Leader>h` is now unmapped and free.

Verified `keymaps.lua` still loads and the OSC52 mappings are unaffected:

```
visual whole file 100KB      PASS  (1.1 ms)
operator ,c2j (linewise)     PASS
operator ,cw (charwise)      PASS
line ,cc                     PASS
line 3,cc (count)            PASS
visual charwise v4l          PASS
visual blockwise             PASS
unnamed register untouched   PASS
register z restored          PASS
'selection' restored         PASS
back in normal mode          PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)