### PR TITLE
nvim: drop backward-looking vim-oscyank references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,7 @@ Key plugins:
 
 **Clipboard over SSH**: `lua/core/osc52.lua` writes OSC 52 escape sequences using
 Neovim's built-in `vim.ui.clipboard.osc52` writer. Mapped to `<leader>c` (operator),
-`<leader>cc` (line), and `<leader>c` in visual mode. This replaced `vim-oscyank`,
-whose pure-Vimscript base64 encoder took ~2.7s to copy 100KB.
+`<leader>cc` (line), and `<leader>c` in visual mode.
 
 ### Zsh Configuration
 

--- a/config/nvim/lua/core/osc52.lua
+++ b/config/nvim/lua/core/osc52.lua
@@ -1,10 +1,7 @@
 -- ~/.config/nvim/lua/core/osc52.lua
 --
 -- Copy to the local system clipboard over SSH via the OSC 52 escape sequence.
---
--- Replaces ojroques/vim-oscyank, whose base64 encoder is a pure-Vimscript loop
--- (~26us per byte: 2.7s to copy 100KB). Neovim's built-in OSC 52 writer uses
--- vim.base64.encode in C, which is ~20000x faster.
+-- Wraps Neovim's built-in OSC 52 writer, which base64-encodes in C.
 
 local M = {}
 

--- a/config/nvim/lua/plugins/init.lua
+++ b/config/nvim/lua/plugins/init.lua
@@ -268,9 +268,6 @@ return {
     },
   },
 
-  -- ========== Other Plugins ==========
-  -- (OSC 52 clipboard is handled natively in core/osc52.lua, no plugin needed)
-
   -- ========== Task Runner ==========
   {
     'stevearc/overseer.nvim',


### PR DESCRIPTION
Follow-up to #24. The plugin is gone from the repo, so comments and docs explaining *what it replaced* and *how slow the old encoder was* are dead weight — describe what the module does instead.

- `core/osc52.lua` header: drop the "Replaces ojroques/vim-oscyank … ~26us per byte … ~20000x faster" paragraph.
- `CLAUDE.md`: drop "This replaced `vim-oscyank`, whose pure-Vimscript base64 encoder took ~2.7s to copy 100KB."
- `plugins/init.lua`: drop the now-empty `-- ========== Other Plugins ==========` header and its placeholder comment, left behind when the plugin spec was removed.

Comments only — no behavior change. Re-ran the OSC52 test suite (12/12 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)